### PR TITLE
ATL-3627: add glossary

### DIFF
--- a/documentation/docs/sidebars.js
+++ b/documentation/docs/sidebars.js
@@ -80,7 +80,7 @@ const sidebars = {
         'atala-prism/getting-help'
       ],
     },
-	'concepts/glossary'
+  'concepts/glossary'
   ],
 };
 


### PR DESCRIPTION
ATL-3627: add the glossary at the bottom of the menu. Note that the glossary still needs to be reviewed and populated but it is a good first iteration.