### PR TITLE
docs: hide enterprise agent sections

### DIFF
--- a/documentation/docs/sidebars.js
+++ b/documentation/docs/sidebars.js
@@ -67,38 +67,6 @@ const sidebars = {
             'atala-prism/prism-cloud-agent/environment-variables'
           ]
         },
-        {
-          type: 'category',
-          label: 'PRISM Cloud Agent Enterprise',
-          collapsed: true,
-          link: {
-            type: 'generated-index',
-            title: 'PRISM Cloud Agent Enterprise',
-            description: 'Learn about the Atala PRISM Cloud Agent Enterprise Services!'
-          },
-          items: [
-            'atala-prism/prism-cloud-agent-enterprise/overview',
-            'atala-prism/prism-cloud-agent-enterprise/onboard',
-            'atala-prism/prism-cloud-agent-enterprise/authenticate',
-            {
-              type: 'category',
-              label: 'Manage',
-              collapsed: true,
-              link: {
-                type: 'generated-index',
-                title: 'Manage',
-                description: 'Learn about the Manage product!'
-              },
-              items: [
-                'atala-prism/prism-cloud-agent-enterprise/manage/overview',
-                'atala-prism/prism-cloud-agent-enterprise/manage/definitions',
-                'atala-prism/prism-cloud-agent-enterprise/manage/setup',
-                'atala-prism/prism-cloud-agent-enterprise/manage/schemas',
-                'atala-prism/prism-cloud-agent-enterprise/manage/policies',
-              ]
-            }
-          ]
-        },
         'atala-prism/prism-node',
         'atala-prism/prism-mediator',
         {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,13 +110,8 @@ const config = {
                                 to: '/agent-api/',
                                 label: 'Agent API',
                                 activeBaseRegex: `/agent-api/`
-                            },
-                            {
-                                to: '/enterprise-api/',
-                                label: 'Enterprise API',
-                                activeBaseRegex: `/enterprise-api/`
                             }
-                        ],
+                        ]
                     },
                     {
                         type: 'dropdown',


### PR DESCRIPTION
We have agreed to hide the PRISM Enterprise documentation sections as per ATL-5660