### PR TITLE
fix: persist CNAME for identus.io custom domain

### DIFF
--- a/.github/workflows/release-gh-pages.yml
+++ b/.github/workflows/release-gh-pages.yml
@@ -45,4 +45,3 @@ jobs:
         with:
           github_token: ${{ secrets.IDENTUS_CI }}
           publish_dir: ./build
-          # cname: doc.did.fmgp.app

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+identus.io


### PR DESCRIPTION
## Problem

The docs site (https://identus.io/) has been repeatedly breaking: the page goes unstyled and shows Docusaurus' red **"Your Docusaurus site did not load properly"** banner, with all `/assets/*` bundles returning 404.

## Root cause

Since #269 the site is built for the `identus.io` apex custom domain (`url: 'https://identus.io/'`, `baseUrl: '/'`). That requires a `CNAME` file on the published `gh-pages` branch.

`release-gh-pages.yml` deploys `./build` to `gh-pages` with `peaceiris/actions-gh-pages@v3` (no `keep_files`), which **replaces the branch on every deploy**. Because there was no `CNAME` in the Docusaurus build, each deploy **deleted the hand-added `gh-pages/CNAME`**, silently disabling the custom domain. GitHub then falls back to serving at the project path `hyperledger-identus.github.io/docs/`, but the build still references assets at root (`baseUrl: '/'`) → `/assets/*` 404 → broken.

This produced ~9 manual `Create CNAME` / `Update CNAME` / `Delete CNAME` commits on `gh-pages` over the last month (by @ryjones, @elribonazo, @patextreme) — each fix only lasting until the next push to `main`.

## Fix

Add `static/CNAME` containing `identus.io`. Docusaurus copies `static/*` into `./build`, so the `CNAME` now ships with every deploy and `peaceiris` preserves it. The custom domain stays enabled permanently; no more manual re-adds.

## Verification

- `static/CNAME` → `build/CNAME` confirmed by Docusaurus static-asset pipeline (same mechanism already used for `static/.nojekyll`).
- After enabling the custom domain in Pages settings, the site renders correctly at https://identus.io/ (home + `/documentation/learn/`): no banner, fully styled, hydrated. `hyperledger-identus.github.io/docs/` 301-redirects to `identus.io`.

## Alternatives considered

- `keep_files: true` on the peaceiris action — works but can leave stale files; `static/CNAME` is the documented Docusaurus approach and is self-contained in the build.
- Reverting to `baseUrl: '/docs/'` — would undo the intentional `identus.io` branding move in #269.